### PR TITLE
Added setup metadata for web config

### DIFF
--- a/roon.json.in
+++ b/roon.json.in
@@ -32,5 +32,6 @@
   \"dependencies\" : [
       { \"name\" : \"app\", \"version\" : \"0.2.0\" },
       { \"name\" : \"remoteOS\", \"version\" : \"0.2.0\" }
-  ]
+  ],
+  \"setup_data\": $$CFG_SCHEMA
 }

--- a/roon.pro
+++ b/roon.pro
@@ -88,3 +88,6 @@ DISTFILES += \
     roon.json.in \
     version.txt.in \
     README.md
+
+# Add setup schema to metadata
+CFG_SCHEMA = "$$cat($$PWD/setup-schema.json)"

--- a/setup-schema.json
+++ b/setup-schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org",
+    "$id": "http://yio-remote.com/yioroon.json",
+    "type": "object",
+    "title": "YIO Roon Integration Schema",
+    "description": "Required data points to set up a YIO Roon integration.",
+    "default": {},
+    "additionalProperties": true,
+    "required": [
+        "ip"
+    ],
+    "properties": {
+        "ip": {
+            "$id": "#/properties/ip",
+            "type": "string",
+            "title": "IP address or hostname",
+            "description": "The IP address or hostname of your Roon Core.",
+            "default": "",
+            "examples": [
+                "192.168.1.100"
+            ]
+        }
+    }
+}

--- a/setup-schema.json
+++ b/setup-schema.json
@@ -14,10 +14,10 @@
             "$id": "#/properties/ip",
             "type": "string",
             "title": "IP address or hostname",
-            "description": "The IP address or hostname of your Roon Core.",
+            "description": "The IP address or hostname of your Roon Core. Optional: the port.",
             "default": "",
             "examples": [
-                "192.168.1.100"
+                "192.168.1.100", "192.168.1.100:9100"
             ]
         }
     }

--- a/src/YioRoon.cpp
+++ b/src/YioRoon.cpp
@@ -81,7 +81,7 @@ YioRoon* YioRoon::_instance = nullptr;
 YioRoon::YioRoon(const QVariantMap& config, EntitiesInterface* entities, NotificationsInterface* notifications,
                  YioAPIInterface* api, ConfigInterface* configObj, Plugin* plugin)
     : Integration(config, entities, notifications, api, configObj, plugin),
-      _roonApi("ws://192.168.1.100:9100/api", "", _reg, m_logCategory),
+      _roonApi("", "", _reg, m_logCategory),
       _browseApi(_roonApi, this),
       _transportApi(_roonApi, transportCallback),
       _subscriptionKey(-1),
@@ -130,8 +130,9 @@ YioRoon::YioRoon(const QVariantMap& config, EntitiesInterface* entities, Notific
     _instance = this;
 
     for (QVariantMap::const_iterator iter = config.begin(); iter != config.end(); ++iter) {
-        if (iter.key() == "ip") {
-            QString ip = iter.value().toString();
+        if (iter.key() == Integration::OBJ_DATA) {
+            QVariantMap map = iter.value().toMap();
+            QString ip = map.value(Integration::KEY_DATA_IP).toString();
             if (!ip.contains(':')) {
                 ip += ":9100";
             }


### PR DESCRIPTION
Okay, this is not ready yet & I need some help. This PR moves the ip config into the data section and adds the appropriate metadata, so that it can be configured via the UI. There are still some pieces missing to have everything work properly with  web config, but it's a start.

Now for the problems:
- When I remove the integration via web-config, my Linux system crashes
- When I add the integration via web-config, I get some exception in the destructor of MediaPlayerUtils. 

Given that the changes are pretty minimal, I suspect that's not due to them. And I have no idea where to start looking.